### PR TITLE
nw:package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 An [ember-cli](http://www.ember-cli.com/) addon for developing Ember.js applications with [NW.js](http://nwjs.io/) (formerly node-webkit).
 
-This addon updates your Ember app with the necessary configuration and scripts to make it run in a NW.js environment.
-It also provides a convenient command (`ember nw`) to both build the app and launch it in a NW.js window.
+* Get started quickly with an application blueprint configured for NW.js.
+* Build, watch, and run the app in NW.js with a convenient command: `ember nw`.
+* Build and package your app for production in one step with the `ember nw:package` command.
 
 ## Installation
 
@@ -22,9 +23,11 @@ This will do the following:
 * Install the addon NPM package (`npm install --save-dev ember-cli-node-webkit`)
 * Run the addon blueprint (`ember generate node-webkit`)
   * Add the blueprint [files](https://github.com/brzpegasus/ember-cli-node-webkit/tree/master/blueprints/node-webkit/files) to your project
-  * Install the [`nw`](https://www.npmjs.com/package/nw) NPM package
+  * Install the [`nw`](https://www.npmjs.com/package/nw) NPM package locally
 
 ## Build, Watch, and Run NW.js
+
+### Command
 
 You can execute `ember build --watch` then start up NW.js with a single command:
 
@@ -32,15 +35,21 @@ You can execute `ember build --watch` then start up NW.js with a single command:
 ember nw
 ```
 
-To specify a specific target environment (e.g. `development` or `production`):
-
-```
-ember nw --environment=<ENV_NAME>
-```
-
 As the app gets rebuilt during development, the NW.js window will automatically reload the current page, so you can see the changes that you made without having to stop and restart the entire process.
 
-## NW.js Binary
+### Options
+
+The following command line options let you specify a target environment or change the directory where the built assets are stored.
+
+**`--environment`** _(String)_ (Default: 'development')
+ * Target environment for the Ember app build
+ * Alias: `-e <value>, -dev (--environment=development), -prod (--environment=production)`
+
+**`--output-path`** _(Path)_ (Default: 'dist/')
+ * Output directory for the Ember app build
+ * Aliases: `-o <value>`
+
+### NW.js Binary
 
 This addon is configured to install NW.js from [NPM](https://www.npmjs.com/package/nw) and add it to your project as a local dependency.
 
@@ -52,7 +61,63 @@ To use a different NW.js:
 
 ## Packaging
 
-See https://github.com/brzpegasus/ember-cli-node-webkit/issues/6.
+### Command
+
+```
+ember nw:package
+```
+
+This command builds your Ember app, assembles all the assets necessary for NW.js, then generates the final executable using [`node-webkit-builder`](https://github.com/mllrsohn/node-webkit-builder).
+
+### Options
+
+You can pass the following command line options:
+
+**`--environment`** _(String)_ (Default: 'production')
+ * Target environment for the Ember app build
+ * Alias: `-e <value>, -dev (--environment=development), -prod (--environment=production)`
+
+**`--output-path`** _(path)_ (Default: 'dist/')
+ * Output directory for the Ember app build
+ * Aliases: `-o <value>`
+
+**`--config-file`** _(String)_ (Default: './config/nw-package.js')
+ * Configuration file for `node-webkit-builder`
+ * Aliases: `-f <value>`
+
+### Configuring node-webkit-builder
+
+`node-webkit-builder` itself comes with a lot of build [options](https://github.com/mllrsohn/node-webkit-builder#options). You can customize any of those settings by supplying a configuration file named `./config/nw-package.js` in your project, or call `ember nw:package` with the `--config-file` option set to the desired file.
+
+#### Configuration File
+
+The configuration file must be a node module that exports a plain object with the names of the options you wish to override as keys:
+
+```javascript
+// ./config/nw-package.js
+
+module.exports = {
+  appName: 'my-nw-app',
+  platforms: ['osx64', 'win64'],
+  buildType: function() {
+    return this.appVersion;
+  }
+};
+```
+
+#### Default Settings
+
+`ember-cli-node-webkit` sets the following options by default:
+
+* **files**
+  * Value: `['package.json', 'dist/**', 'node_modules/<name>/**']`
+  * `'node_modules/<name>/**'` is listed for every non-dev npm dependency declared in your project.
+* **platforms**
+  * Value: `[<current_platform>]`
+* **buildDir**
+  * Value: `build/app`
+* **cacheDir**
+  * Value: `build/cache`
 
 ## Contribution
 
@@ -68,7 +133,7 @@ npm link
 
 Then, in your Ember CLI project:
 
-* Add `ember-cli-node-webkit` to your `package.json`'s dev dependencies. The version doesn't really matter. The package just needs to be listed so that Ember CLI can discover and register your addon:
+* Add `ember-cli-node-webkit` to your `package.json`'s dev dependencies so that Ember CLI can discover and register the addon:
 
 ```json
 {
@@ -98,3 +163,7 @@ npm test
 ### Want to Help?
 
 This addon was created to help Ember.js developers build applications in NW.js. If you find patterns that work well for you, or would like to suggest ideas to make this addon even better, feel free to open new issues or submit pull requests. I'd love to hear your feedback!
+
+## License
+
+[Licensed under the MIT license](http://opensource.org/licenses/mit-license.php)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following command line options let you specify a target environment or chang
  * Target environment for the Ember app build
  * Alias: `-e <value>, -dev (--environment=development), -prod (--environment=production)`
 
-**`--output-path`** _(Path)_ (Default: 'dist/')
+**`--output-path`** _(String)_ (Default: 'dist/')
  * Output directory for the Ember app build
  * Aliases: `-o <value>`
 
@@ -77,24 +77,24 @@ You can pass the following command line options:
  * Target environment for the Ember app build
  * Alias: `-e <value>, -dev (--environment=development), -prod (--environment=production)`
 
-**`--output-path`** _(path)_ (Default: 'dist/')
+**`--output-path`** _(String)_ (Default: 'dist/')
  * Output directory for the Ember app build
  * Aliases: `-o <value>`
 
-**`--config-file`** _(String)_ (Default: './config/nw-package.js')
+**`--config-file`** _(String)_ (Default: 'config/nw-package.js')
  * Configuration file for `node-webkit-builder`
  * Aliases: `-f <value>`
 
 ### Configuring node-webkit-builder
 
-`node-webkit-builder` itself comes with a lot of build [options](https://github.com/mllrsohn/node-webkit-builder#options). You can customize any of those settings by supplying a configuration file named `./config/nw-package.js` in your project, or call `ember nw:package` with the `--config-file` option set to the desired file.
+`node-webkit-builder` itself comes with a lot of build [options](https://github.com/mllrsohn/node-webkit-builder#options). You can customize any of those settings by supplying a configuration file named `config/nw-package.js` in your project, or call `ember nw:package` with the `--config-file` option set to the desired file.
 
 #### Configuration File
 
 The configuration file must be a node module that exports a plain object with the names of the options you wish to override as keys:
 
 ```javascript
-// ./config/nw-package.js
+// config/nw-package.js
 
 module.exports = {
   appName: 'my-nw-app',

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = {
 
   includedCommands: function() {
     return {
-      nw: require('./lib/commands/nw')
+      'nw': require('./lib/commands/nw'),
+      'nw:package': require('./lib/commands/nw-package')
     }
   }
 };

--- a/lib/commands/nw-package.js
+++ b/lib/commands/nw-package.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var fs        = require('fs');
+var path      = require('path');
+var chalk     = require('chalk');
+var NwBuilder = require('node-webkit-builder');
+
+module.exports = {
+  name: 'nw:package',
+  description: 'Packages your NW.js app',
+
+  availableOptions: [
+    { name: 'environment', type: String, default: 'production', aliases: ['e', { 'dev' : 'development' }, { 'prod' : 'production' }] },
+    { name: 'output-path', type: path, default: 'dist/', aliases: ['o'] },
+    { name: 'config-file', type: String, default: './config/nw-package.js', aliases: ['f'] }
+  ],
+
+  buildApp: function(options) {
+    var buildTask = new this.tasks.Build({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+
+    return buildTask.run(options);
+  },
+
+  packageApp: function(options) {
+    var ui = this.ui;
+
+    ui.writeLine(chalk.green('Packaging...'));
+
+    var config = this.nwConfig(options);
+    var nw = new NwBuilder(config);
+    nw.on('log', console.log);
+
+    return nw.build().then(function() {
+      ui.writeLine(chalk.green('Packaged project successfully.'));
+    });
+  },
+
+  nwConfig: function(options) {
+    var config = {};
+
+    var configFile = path.resolve(this.project.root, options.configFile);
+    if (fs.existsSync(configFile)) {
+      config = require(configFile);
+    }
+
+    if (!config.buildDir) { config.buildDir = 'build/app'; }
+    if (!config.cacheDir) { config.cacheDir = 'build/cache'; }
+
+    if (!config.files) {
+      config.files = this.nwFiles(options);
+    }
+
+    if (!config.platforms) {
+      var detectPlatform = require('../helpers/detect-platform');
+      var currentPlatform = detectPlatform();
+      if (currentPlatform) {
+        config.platforms = [currentPlatform];
+      }
+    }
+
+    return config;
+  },
+
+  nwFiles: function(options) {
+    var nwFiles = ['package.json'];
+
+    // Contents of the build output directory
+    nwFiles.push(options.outputPath.replace(/\/?$/, '/**'));
+
+    // Non-dev NPM modules
+    var npmModulesRoot = 'node_modules';
+    var npmDependencies = this.project.pkg.dependencies || {};
+
+    Object.keys(npmDependencies).forEach(function(dependency) {
+      nwFiles.push(npmModulesRoot + '/' + dependency + '/**');
+    });
+
+    return nwFiles;
+  },
+
+  run: function(options) {
+    var _this = this;
+
+    return this.buildApp(options)
+      .then(function() {
+        return _this.packageApp(options);
+      });
+  }
+};

--- a/lib/commands/nw-package.js
+++ b/lib/commands/nw-package.js
@@ -11,8 +11,8 @@ module.exports = {
 
   availableOptions: [
     { name: 'environment', type: String, default: 'production', aliases: ['e', { 'dev' : 'development' }, { 'prod' : 'production' }] },
-    { name: 'output-path', type: path, default: 'dist/', aliases: ['o'] },
-    { name: 'config-file', type: String, default: './config/nw-package.js', aliases: ['f'] }
+    { name: 'output-path', type: String, default: 'dist/', aliases: ['o'] },
+    { name: 'config-file', type: String, default: 'config/nw-package.js', aliases: ['f'] }
   ],
 
   buildApp: function(options) {

--- a/lib/commands/nw.js
+++ b/lib/commands/nw.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var path  = require('path');
 var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var RSVP  = require('rsvp');
@@ -13,7 +12,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'environment', type: String, default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
-    { name: 'output-path', type: path, default: 'dist/', aliases: ['o'] }
+    { name: 'output-path', type: String, default: 'dist/', aliases: ['o'] }
   ],
 
   buildWatch: function(options) {

--- a/lib/helpers/detect-platform.js
+++ b/lib/helpers/detect-platform.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function() {
+  switch (process.platform) {
+    case 'darwin':
+      return process.arch === 'x64' ? 'osx64' : 'osx32';
+
+    case 'win32':
+      return (process.arch === 'x64' || process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432')) ? 'win64' : 'win32';
+
+    case 'linux':
+      return process.arch === 'x64' ? 'linux64' : 'linux32';
+  }
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mocha": "^2.2.1",
     "mocha-jshint": "^1.0.0",
     "mock-spawn": "^0.2.4",
-    "mockery": "^1.4.0"
+    "mockery": "^1.4.0",
+    "sinon": "^1.14.1"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^1.0.0",
+    "node-webkit-builder": "^1.0.11",
     "rsvp": "^3.0.17"
   },
   "devDependencies": {

--- a/tests/fixtures/project-with-config/config/nw-package.js
+++ b/tests/fixtures/project-with-config/config/nw-package.js
@@ -1,0 +1,8 @@
+module.exports = {
+  buildDir: 'build',
+  cacheDir: 'cache',
+  files: ['package.json'],
+  platforms: ['osx64', 'win64'],
+  appName: 'foo',
+  appVersion: '0.0.1'
+};

--- a/tests/fixtures/project-with-config/custom-nw-package.js
+++ b/tests/fixtures/project-with-config/custom-nw-package.js
@@ -1,0 +1,6 @@
+module.exports = {
+  buildDir: 'build/release',
+  platforms: ['win64'],
+  appName: 'bar',
+  appVersion: '0.0.1'
+};

--- a/tests/helpers/mocks/node-webkit-builder.js
+++ b/tests/helpers/mocks/node-webkit-builder.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var RSVP = require('rsvp');
+
+function MockNodeWebkitBuilder(options) {
+  this.options = options;
+}
+
+module.exports = MockNodeWebkitBuilder;
+
+MockNodeWebkitBuilder.prototype.on = function() {
+};
+
+MockNodeWebkitBuilder.prototype.build = function() {
+  return RSVP.resolve(this.options);
+};

--- a/tests/helpers/mocks/project.js
+++ b/tests/helpers/mocks/project.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var path = require('path');
+
+function MockProject(name, pkg) {
+  this.name = name;
+  this.pkg = pkg || {};
+  this.root = path.resolve(__dirname, '..', '..', 'fixtures', name);
+}
+
+module.exports = MockProject;
+
+MockProject.prototype.isEmberCLIProject = function() {
+  return true;
+};

--- a/tests/unit/commands/nw-package-test.js
+++ b/tests/unit/commands/nw-package-test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+var path          = require('path');
+var mockery       = require('mockery');
+var RSVP          = require('rsvp');
+var sinon         = require('sinon');
+var Command       = require('ember-cli/lib/models/command');
+var Task          = require('ember-cli/lib/models/task');
+var MockUI        = require('ember-cli/tests/helpers/mock-ui');
+var MockAnalytics = require('ember-cli/tests/helpers/mock-analytics');
+var MockNWBuilder = require('../../helpers/mocks/node-webkit-builder');
+var MockProject   = require('../../helpers/mocks/project');
+var expect        = require('../../helpers/expect');
+
+describe("ember nw:package command", function() {
+  var CommandUnderTest, commandOptions, nwBuild;
+
+  before(function() {
+    mockery.enable({
+      useCleanCache: true,
+      warnOnUnregistered: false
+    });
+
+    mockery.registerMock('node-webkit-builder', MockNWBuilder);
+    mockery.registerMock('../helpers/detect-platform', function() {
+      return 'osx64';
+    });
+
+    var cmd = require('../../../lib/commands/nw-package');
+    CommandUnderTest = Command.extend(cmd);
+  });
+
+  after(function() {
+    mockery.disable();
+  });
+
+  beforeEach(function() {
+    commandOptions = {
+      ui: new MockUI(),
+      analytics: new MockAnalytics(),
+      settings: {},
+      project: new MockProject('project-empty', {
+        dependencies: {
+          rsvp: '^3.0.17',
+          wrench: '^1.5.8'
+        }
+      }),
+      tasks: {
+        Build: Task.extend({
+          run: function() {
+            return RSVP.resolve();
+          }
+        })
+      }
+    };
+
+    nwBuild = sinon.spy(MockNWBuilder.prototype, 'build');
+  });
+
+  afterEach(function() {
+    MockNWBuilder.prototype.build.restore();
+  });
+
+  it("should build the project before packaging", function() {
+    var tasks = [];
+
+    commandOptions.tasks = {
+      Build: Task.extend({
+        run: function() {
+          tasks.push('build');
+          return RSVP.resolve();
+        }
+      })
+    };
+
+    commandOptions.packageApp = function() {
+      tasks.push('package');
+      return RSVP.resolve();
+    };
+
+    var command = new CommandUnderTest(commandOptions).validateAndRun();
+
+    return expect(command).to.be.fulfilled
+      .then(function() {
+        expect(tasks).to.deep.equal(['build', 'package']);
+      });
+  });
+
+  it("should package the app with the right default configuration", function() {
+    var command = new CommandUnderTest(commandOptions).validateAndRun();
+
+    return expect(command).to.be.fulfilled
+      .then(function(options) {
+        expect(nwBuild.calledOnce).to.be.true;
+
+        var defaultConfig = {
+          buildDir: 'build/app',
+          cacheDir: 'build/cache',
+          files: [
+            'package.json',
+            'dist/**',
+            'node_modules/rsvp/**',
+            'node_modules/wrench/**'
+          ],
+          platforms: ['osx64']
+        };
+
+        var promise = nwBuild.returnValues[0];
+        return expect(promise).to.eventually.deep.equal(defaultConfig);
+      });
+  });
+
+  it("should package the app with the configuration specified by the default config file", function() {
+    commandOptions.project = new MockProject('project-with-config');
+
+    var command = new CommandUnderTest(commandOptions).validateAndRun();
+
+    return expect(command).to.be.fulfilled
+      .then(function(options) {
+        expect(nwBuild.calledOnce).to.be.true;
+
+        var customConfig = {
+          buildDir: 'build',
+          cacheDir: 'cache',
+          files: ['package.json'],
+          platforms: ['osx64', 'win64'],
+          appName: 'foo',
+          appVersion: '0.0.1'
+        };
+
+        var promise = nwBuild.returnValues[0];
+        return expect(promise).to.eventually.deep.equal(customConfig);
+      });
+  });
+
+  it("should package the app with the configuration specified by the custom config file", function() {
+    commandOptions.project = new MockProject('project-with-config');
+
+    var command = new CommandUnderTest(commandOptions).validateAndRun(['--config-file=custom-nw-package.js']);
+
+    return expect(command).to.be.fulfilled
+      .then(function(options) {
+        expect(nwBuild.calledOnce).to.be.true;
+
+        var customConfig = {
+          buildDir: 'build/release',
+          cacheDir: 'build/cache',
+          files: [
+            'package.json',
+            'dist/**'
+          ],
+          platforms: ['win64'],
+          appName: 'bar',
+          appVersion: '0.0.1'
+        };
+
+        var promise = nwBuild.returnValues[0];
+        return expect(promise).to.eventually.deep.equal(customConfig);
+      });
+  });
+});

--- a/tests/unit/helpers/find-nw-test.js
+++ b/tests/unit/helpers/find-nw-test.js
@@ -13,8 +13,10 @@ describe("The command to start NW.js", function() {
 
   describe("when the `nw` npm package is installed", function() {
     before(function() {
-      mockery.enable({ useCleanCache: true });
-      mockery.warnOnUnregistered(false);
+      mockery.enable({
+        useCleanCache: true,
+        warnOnUnregistered: false
+      });
     });
 
     after(function() {


### PR DESCRIPTION
New command to package the application:

* `ember nw:package`
* Includes a pre-packaging build step.
* Packages the app with [`node-webkit-builder`](https://github.com/mllrsohn/node-webkit-builder) with pre-defined configuration settings.
* Provides a mechanism to override packaging options.

Closes #6