### PR TITLE
implemented ember nw:test to run tests with nwjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
-
+.DS_STORE
 # compiled output
 /dist
 /tmp

--- a/blueprints/node-webkit/files/nw-runner.js
+++ b/blueprints/node-webkit/files/nw-runner.js
@@ -1,0 +1,29 @@
+var exec = require('child_process').exec;
+var findNw = require('./node_modules/ember-cli-node-webkit/lib/helpers/find-nw');
+runNw(findNw({
+  root: './'
+}));
+
+function runNw(nwPath) {
+  var nw = exec(nwPath + ' ./dist/tests');
+  nw.stdout.on('data', function (data) {
+    process.stdout.write(data);
+  });
+
+  // Cleanup nw.js output to be TAP (test anything protocol) compliant
+  nw.stderr.on('data', function (data) {
+    if (data.indexOf('[qunit-logger]') > -1) {
+      data = data.replace(/\[.*\] /g, "");
+      data = data.replace(/\, source.*/g, "");
+      data = data.replace(/\"/g, "");
+      data = data.replace('[qunit-logger] ', '');
+      console.log(data);
+    }
+  });
+
+  nw.on('exit', function (code) {
+    setTimeout(function () {
+      process.exit(code);
+    }, 2000);
+  });
+}

--- a/blueprints/node-webkit/files/tests/package.json
+++ b/blueprints/node-webkit/files/tests/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ember-nw-test",
+  "main": "index.html"
+}

--- a/blueprints/node-webkit/files/tests/testem-nw.json
+++ b/blueprints/node-webkit/files/tests/testem-nw.json
@@ -1,0 +1,16 @@
+{
+  "framework": "qunit",
+  "test_page": "tests/index.html?hidepassed",
+  "launch_in_ci": [
+    "nw"
+  ],
+  "launch_in_dev": [
+    "nw"
+  ],
+  "launchers": {
+    "nw": {
+        "command": "node nw-runner.js",
+        "protocol": "tap"
+    }
+  }
+}

--- a/blueprints/node-webkit/files/vendor/node-webkit/qunit-logger.js
+++ b/blueprints/node-webkit/files/vendor/node-webkit/qunit-logger.js
@@ -1,0 +1,63 @@
+/* global define */
+/* global window */
+/* global QUnit */
+// dead stupid script to format test output from nw.js to the console
+define('vendor/node-webkit/qunit-logger', function () {
+  function log(content) {
+    console.log('[qunit-logger] ' + content);
+  }
+
+  if (!window.nwDispatcher) {
+    return;
+  }
+
+  var totalTestCount = 0;
+  var testCount = 0;
+  var tests = {};
+  QUnit.begin(function (details) {
+    if (details.totalTests >= 1) {
+      totalTestCount = details.totalTests;
+      log('1...' + details.totalTests);
+    }
+  });
+
+  QUnit.testDone(function (details) {
+    testCount++;
+    if (details.failed === 0 && !tests[details.name]) {
+      tests[details.name] = details.name;
+      log('ok ' + testCount + ' - ' + details.module + ' # ' + details.name);
+    }
+  });
+
+  QUnit.log(function (details) {
+    if (details.result !== true) {
+      var actualTestCount = testCount + 1;
+      log('not ok ' + actualTestCount + ' - ' + details.module + ' - ' + details.name);
+      log('#    actual: -');
+      log('#      ' + details.actual);
+      log('#    expected: -');
+      log('#      ' + details.expected);
+      log('#    message: -');
+      log('#      ' + details.message);
+      if (details.source) {
+        log('#      ' + details.source);
+      }
+
+      log('#    Log:');
+      if (details.log) {
+        log('#      ' + details.log);
+      }
+    }
+  });
+
+  QUnit.done(function (details) {
+    var gui = require('nw.gui');
+    if (details.failed === 0) {
+      // quit with no error
+      gui.App.quit();
+    } else {
+      // fail out
+      gui.App.crashRenderer();
+    }
+  });
+})();

--- a/blueprints/node-webkit/files/vendor/node-webkit/reload.js
+++ b/blueprints/node-webkit/files/vendor/node-webkit/reload.js
@@ -4,8 +4,11 @@
 
   // Reload the page when anything in `dist` changes
   var fs = window.requireNode('fs');
+  var watchDir = './dist';
 
-  fs.watch('./dist', function() {
-    window.location.reload();
-  });
+  if (fs.existsSync(watchDir)) {
+    fs.watch(watchDir, function() {
+      window.location.reload();
+    });
+  }
 })();

--- a/blueprints/node-webkit/index.js
+++ b/blueprints/node-webkit/index.js
@@ -21,11 +21,13 @@ module.exports = {
     var dependencies = this.project.dependencies();
 
     return this.addNwConfig(options)
-      .then(function() {
-        if (!dependencies.nw) {
-          return _this.addPackageToProject('nw');
-        }
-      });
+    .then(function () {
+      if (!dependencies.nw) {
+        return _this.addPackageToProject('nw');
+      }
+    }).then(function () {
+      return _this.addQUnitLogger();
+    });
   },
 
   addNwConfig: function(options) {
@@ -49,6 +51,23 @@ module.exports = {
       if (!options.dryRun) {
         return writeFile(packageJsonPath, JSON.stringify(json, null, '  '));
       }
+    });
+  },
+
+  addQUnitLogger: function() {
+    var testHelperFile = path.resolve(this.project.root, 'tests/test-helper.js');
+    var ui = this.ui;
+
+    return readFile(testHelperFile, { encoding: 'utf8' })
+    .then(function(data) {
+      var code = 'import \'vendor/node-webkit/qunit-logger\';';
+
+      if (data.indexOf(code) < 0) {
+        ui.writeLine(chalk.yellow('modifying tests/test-helper.js to import vendor/node-webkit/qunit-logger'));
+        data = data + '\n// placed by ember-cli-node-webkit \n' + code;
+      }
+
+      return writeFile(testHelperFile, data);
     });
   }
 };

--- a/index.js
+++ b/index.js
@@ -7,13 +7,15 @@ module.exports = {
     this._super.included(app);
 
     app.import('vendor/node-webkit/shim.js', { prepend: true });
+    app.import('vendor/node-webkit/qunit-logger.js');
     app.import({ development: 'vendor/node-webkit/reload.js' });
   },
 
   includedCommands: function() {
     return {
       'nw': require('./lib/commands/nw'),
-      'nw:package': require('./lib/commands/nw-package')
+      'nw:package': require('./lib/commands/nw-package'),
+      'nw:test' : require('./lib/commands/nw-test')
     }
   }
 };

--- a/lib/commands/nw-test.js
+++ b/lib/commands/nw-test.js
@@ -1,0 +1,59 @@
+'use strict';
+var chalk = require('chalk');
+var RSVP = require('rsvp');
+var path = require('path');
+var denodeify = RSVP.denodeify;
+var fs = require('fs');
+var readFile = denodeify(fs.readFile);
+var writeFile = denodeify(fs.writeFile);
+module.exports = {
+  name: 'nw:test',
+  description: 'Runs your test suite in NW.js',
+  availableOptions: [{
+    name: 'environment',
+    type: String,
+    default: 'test',
+    aliases: ['e', {
+      'dev': 'development'
+    }, {
+      'prod': 'production'
+    }]
+  }, {
+    name: 'output-path',
+    type: String,
+    default: 'dist/',
+    aliases: ['o']
+  }],
+  run: function (options) {
+    var _this = this;
+    var ui = this.ui;
+    ui.startProgress(chalk.green('Building'), chalk.green('.'));
+    var buildTask = new this.tasks.Build({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project,
+      environment: options.environment
+    });
+    var testHtmlPath = path.resolve(_this.project.root, 'dist/tests/index.html');
+    return buildTask.run(options).then(function () {
+        return readFile(testHtmlPath, {
+          encoding: 'utf8'
+        });
+      })
+      .then(function (rawHTML) {
+        rawHTML = rawHTML.replace('base href=\"/\"', 'base href="../"');
+        return writeFile(testHtmlPath, rawHTML);
+      })
+      .then(function () {
+        // copy test package.json for nwjs
+        var stream = fs.createReadStream(path.resolve(_this.project.root, 'tests/package.json'));
+        stream.pipe(fs.createWriteStream(path.resolve(options.outputPath, 'tests/package.json')));
+        var testTask = new _this.tasks.Test({
+          project: _this.project
+        });
+        return testTask.run({
+          configFile: path.resolve(_this.project.root, 'tests/testem-nw.json')
+        });
+      });
+  }
+};


### PR DESCRIPTION
Here's my first shot -

After the installation I insert `require('qunit-logger')` into `tests/test-helper.js`. The command `ember nw` is setup to build the app and copy the package.json (in my project I used broccoli but I wanted to keep from mucking with the user's app build). Afterwards the command sneaks in a `baseUrl="../"` tag in `dist/tests/index.html` starts up `ember test` with the testem configuration set to `tests/testem-nw.json`.

So all a user has to do is just install the plugin and do `ember nw:test`. Thoughts?