### PR TITLE
Allow NW.js testem config file to be specified via a command line option

### DIFF
--- a/lib/commands/nw-test.js
+++ b/lib/commands/nw-test.js
@@ -1,57 +1,61 @@
 'use strict';
-var chalk = require('chalk');
-var RSVP = require('rsvp');
-var path = require('path');
-var denodeify = RSVP.denodeify;
+
 var fs = require('fs');
+var path = require('path');
+var RSVP = require('rsvp');
+
+var denodeify = RSVP.denodeify;
 var readFile = denodeify(fs.readFile);
 var writeFile = denodeify(fs.writeFile);
+
 module.exports = {
   name: 'nw:test',
   description: 'Runs your test suite in NW.js',
-  availableOptions: [{
-    name: 'environment',
-    type: String,
-    default: 'test',
-    aliases: ['e', {
-      'dev': 'development'
-    }, {
-      'prod': 'production'
-    }]
-  }, {
-    name: 'output-path',
-    type: String,
-    default: 'dist/',
-    aliases: ['o']
-  }],
-  run: function (options) {
-    var _this = this;
-    var ui = this.ui;
-    ui.startProgress(chalk.green('Building'), chalk.green('.'));
-    var buildTask = new this.tasks.Build({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-      environment: options.environment
-    });
-    var testHtmlPath = path.resolve(_this.project.root, 'dist/tests/index.html');
-    return buildTask.run(options).then(function () {
-        return readFile(testHtmlPath, {
-          encoding: 'utf8'
-        });
-      })
-      .then(function (rawHTML) {
-        rawHTML = rawHTML.replace('base href=\"/\"', 'base href="../"');
+
+  availableOptions: [
+    { name: 'environment', type: String, default: 'test', aliases: ['e'] },
+    { name: 'output-path', type: String, default: 'dist/', aliases: ['o'] }
+  ],
+
+  prepareTestFiles: function(options) {
+    var root = this.project.root;
+    var outputPath = options.outputPath;
+    var testHtmlPath = path.resolve(root, outputPath, 'tests/index.html');
+
+    return readFile(testHtmlPath, { encoding: 'utf8' })
+      .then(function(rawHTML) {
+        rawHTML = rawHTML.replace(/base href="\/"/, 'base href="../"');
         return writeFile(testHtmlPath, rawHTML);
       })
-      .then(function () {
+      .then(function() {
         // copy test package.json for nwjs
-        var stream = fs.createReadStream(path.resolve(_this.project.root, 'tests/package.json'));
-        stream.pipe(fs.createWriteStream(path.resolve(options.outputPath, 'tests/package.json')));
-        var testTask = new _this.tasks.Test({
-          project: _this.project
-        });
+        var stream = fs.createReadStream(path.resolve(root, 'tests/package.json'));
+        stream.pipe(fs.createWriteStream(path.resolve(outputPath, 'tests/package.json')));
+      });
+  },
+
+  run: function(commandOptions) {
+    var _this = this;
+
+    var options = {
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    };
+
+    var testTask = new this.tasks.Test(options);
+    var buildTask = new this.tasks.Build(options);
+
+    return buildTask.run({
+        environment: commandOptions.environment,
+        outputPath: commandOptions.outputPath
+      })
+      .then(function() {
+        return _this.prepareTestFiles(commandOptions);
+      })
+      .then(function() {
         return testTask.run({
+          outputPath: commandOptions.outputPath,
           configFile: path.resolve(_this.project.root, 'tests/testem-nw.json')
         });
       });

--- a/lib/commands/nw-test.js
+++ b/lib/commands/nw-test.js
@@ -13,6 +13,7 @@ module.exports = {
   description: 'Runs your test suite in NW.js',
 
   availableOptions: [
+    { name: 'config-file', type: String, aliases: ['c', 'cf'] },
     { name: 'environment', type: String, default: 'test', aliases: ['e'] },
     { name: 'output-path', type: String, default: 'dist/', aliases: ['o'] }
   ],
@@ -56,7 +57,7 @@ module.exports = {
       .then(function() {
         return testTask.run({
           outputPath: commandOptions.outputPath,
-          configFile: path.resolve(_this.project.root, 'tests/testem-nw.json')
+          configFile: commandOptions.configFile || path.join(__dirname, '..', 'testem.json')
         });
       });
   }

--- a/lib/testem.json
+++ b/lib/testem.json
@@ -9,8 +9,8 @@
   ],
   "launchers": {
     "nw": {
-        "command": "node nw-runner.js",
-        "protocol": "tap"
+      "command": "node nw-runner.js",
+      "protocol": "tap"
     }
   }
 }


### PR DESCRIPTION
* Hide testem config inside the addon rather than exposing it as a blueprint file
* Add config option to `nw-test` command to override the testem file