### PR TITLE
Move QUnit Logger to `test-support` directory

### DIFF
--- a/blueprints/node-webkit/index.js
+++ b/blueprints/node-webkit/index.js
@@ -55,19 +55,26 @@ module.exports = {
   },
 
   addQUnitLogger: function() {
-    var testHelperFile = path.resolve(this.project.root, 'tests/test-helper.js');
     var ui = this.ui;
+    var testHelperFile = path.resolve(this.project.root, 'tests/test-helper.js');
 
     return readFile(testHelperFile, { encoding: 'utf8' })
-    .then(function(data) {
-      var code = 'import \'vendor/node-webkit/qunit-logger\';';
+      .then(function(data) {
+        if (data.indexOf('node-webkit/qunit-logger') < 0) {
+          ui.writeLine('  ' + chalk.yellow('overwrite') + ' tests/test-helper.js');
 
-      if (data.indexOf(code) < 0) {
-        ui.writeLine(chalk.yellow('modifying tests/test-helper.js to import vendor/node-webkit/qunit-logger'));
-        data = data + '\n// placed by ember-cli-node-webkit \n' + code;
-      }
+          var code = [
+            "",
+            "// Added by ember-cli-node-webkit",
+            "import { setQUnitLogger } from './node-webkit/qunit-logger';",
+            "",
+            "setQUnitLogger();"
+          ];
 
-      return writeFile(testHelperFile, data);
-    });
+          data = data + code.join('\n');
+        }
+
+        return writeFile(testHelperFile, data);
+      });
   }
 };

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports = {
     this._super.included(app);
 
     app.import('vendor/node-webkit/shim.js', { prepend: true });
-    app.import('vendor/node-webkit/qunit-logger.js');
     app.import({ development: 'vendor/node-webkit/reload.js' });
   },
 

--- a/lib/commands/nw-test/runner.js
+++ b/lib/commands/nw-test/runner.js
@@ -30,6 +30,6 @@ function runNw(nwPath, testsPath) {
   nw.on('exit', function(code) {
     setTimeout(function() {
       process.exit(hasErrors ? 1 : code);
-    }, 2000);
+    }, 1);
   });
 }

--- a/test-support/node-webkit/qunit-logger.js
+++ b/test-support/node-webkit/qunit-logger.js
@@ -1,10 +1,11 @@
-/* global define, window, QUnit */
 // dead stupid script to format test output from nw.js to the console
-define('vendor/node-webkit/qunit-logger', function () {
-  function log(content) {
-    console.log('[qunit-logger] ' + content);
-  }
+import QUnit from 'qunit';
 
+function log(content) {
+  console.log('[qunit-logger] ' + content);
+}
+
+export function setQUnitLogger() {
   if (!window.nwDispatcher) {
     return;
   }
@@ -13,14 +14,14 @@ define('vendor/node-webkit/qunit-logger', function () {
   var testCount = 0;
   var tests = {};
 
-  QUnit.begin(function (details) {
+  QUnit.begin(function(details) {
     if (details.totalTests >= 1) {
       totalTestCount = details.totalTests;
       log('1..' + details.totalTests);
     }
   });
 
-  QUnit.testDone(function (details) {
+  QUnit.testDone(function(details) {
     testCount++;
     if (details.failed === 0 && !tests[details.name]) {
       tests[details.name] = details.name;
@@ -28,7 +29,7 @@ define('vendor/node-webkit/qunit-logger', function () {
     }
   });
 
-  QUnit.log(function (details) {
+  QUnit.log(function(details) {
     if (details.result !== true) {
       var actualTestCount = testCount + 1;
       log('# ' + JSON.stringify(details));
@@ -40,4 +41,4 @@ define('vendor/node-webkit/qunit-logger', function () {
     log('# done' + (details.failed === 0 ? '' : ' with errors'));
     require('nw.gui').App.quit();
   });
-});
+}


### PR DESCRIPTION
* Add `qunit-logger.js` to `test-support/node-webkit/` as it doesn't need to be tweaked by users of the consuming app.
* This should reduce the number of blueprint files, and hopefully make future upgrades a bit easier to manage.
* Update the logger code to use ES2015 modules instead of AMD.