### PR TITLE
Add travis config blueprint to run `ember nw:test` with xvfb.

### DIFF
--- a/blueprints/node-webkit/files/.travis.yml
+++ b/blueprints/node-webkit/files/.travis.yml
@@ -1,0 +1,23 @@
+---
+language: node_js
+node_js:
+  - "0.12"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
+
+install:
+  - npm install -g bower
+  - npm install
+  - bower install
+
+script:
+  - xvfb-run ember nw:test


### PR DESCRIPTION
Update `.travis.yml` to make it possible to run `ember nw:test` on Travis with [xvfb](http://en.wikipedia.org/wiki/Xvfb).

* [Example of failed Travis build](https://travis-ci.org/brzpegasus/ember-nw-markdown/builds/60133612)
* [Example of successful Travis build](https://travis-ci.org/brzpegasus/ember-nw-markdown/builds/60134193)