### PR TITLE
feat(tests/infra) - interactive mode implementation

### DIFF
--- a/blueprints/node-webkit/files/tests/package.json
+++ b/blueprints/node-webkit/files/tests/package.json
@@ -2,6 +2,6 @@
   "name": "ember-nw-test",
   "main": "index.html",
   "window": {
-    "show": false
+    "show": true
   }
 }

--- a/blueprints/node-webkit/index.js
+++ b/blueprints/node-webkit/index.js
@@ -45,7 +45,6 @@ module.exports = {
       var json = JSON.parse(data);
       json.main = 'dist/index.html';
       json.window = { width: 960, height: 600 };
-
       ui.writeLine('  ' + chalk.yellow('overwrite') + ' package.json');
 
       if (!options.dryRun) {

--- a/index.js
+++ b/index.js
@@ -16,5 +16,40 @@ module.exports = {
       'nw:package': require('./lib/commands/nw-package'),
       'nw:test' : require('./lib/commands/nw-test')
     }
+  },
+  
+  postprocessTree: function(type, tree) {
+    var funnel = require('broccoli-funnel');
+    var mergeTrees = require('broccoli-merge-trees');
+    var replace = require('broccoli-string-replace');
+  
+    if (type === 'all' && process.env.EMBER_ENV === 'test') {
+      // Update the base URL in `tests/index.html`
+      var index = replace(tree, {
+        files: ['tests/index.html'],
+        pattern: {
+          match: /base href="\/"/,
+          replacement: 'base href="../"'
+        }
+      });
+  
+      // Copy `tests/package.json` to the output directory
+      var testPkg = funnel('tests', {
+        files: ['package.json'],
+        destDir: '/tests'
+      });
+  
+      return mergeTrees([tree, index, testPkg], { overwrite: true });
+    }
+  
+    return tree;
+  },
+
+  contentFor: function(type) {
+    // TODO Make testem server URL configurable
+    var testemServer = 'http://localhost:7357';
+    if (type === 'test-body' && process.env.EMBER_ENV === 'test') {
+      return '<script src="' + testemServer + '/socket.io/socket.io.js"></script>';
+    }
   }
 };

--- a/lib/commands/nw-test/index.js
+++ b/lib/commands/nw-test/index.js
@@ -3,10 +3,10 @@
 var fs = require('fs');
 var path = require('path');
 var RSVP = require('rsvp');
-
 var denodeify = RSVP.denodeify;
 var readFile = denodeify(fs.readFile);
 var writeFile = denodeify(fs.writeFile);
+var Builder = require('ember-cli/lib/models/builder');
 
 function safePath(filePath) {
   // Guard against file paths that contain spaces
@@ -19,6 +19,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'config-file', type: String, aliases: ['c', 'cf'] },
+    { name: 'server', type: Boolean, default: false },
     { name: 'environment', type: String, default: 'test', aliases: ['e'] }
   ],
 
@@ -83,7 +84,6 @@ module.exports = {
           cwd: options.outputPath,
           middleware: this.addonMiddlewares(),
           launch_in_ci: ['NW.js'],
-          launch_in_dev: ['NW.js'],
           launchers: {
             'NW.js': {
               command: testCommand,
@@ -102,13 +102,71 @@ module.exports = {
     });
   },
 
+  runTestsServer: function(options) {
+    var _this = this;
+    var BaseTestTask = this.tasks.TestServer;
+    var TestTask = BaseTestTask.extend({
+      testemOptions: function() {
+        var findNW = require('../../helpers/find-nw');
+        var nwPath = safePath(findNW(_this.project));
+        var testPath = safePath(path.join(options.outputPath, 'tests'));
+        var testCommand = nwPath + ' ' + testPath;
+        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+        return {
+          cwd: options.outputPath,
+          middleware: this.addonMiddlewares(),
+          reporter: require('./reporter'),
+          hide_stderr: false,
+          hide_stdout: false,
+          launch_in_dev: ['NW.js'],
+          launchers: {
+            'NW.js': {
+              command: testCommand,
+              protocol: 'browser'
+            }
+          }
+        };
+      }
+    });
+
+    var testTask = new TestTask(this.taskOptions());
+    var ui = this.ui;
+    var Watcher = require('ember-cli/lib/models/watcher');
+
+    var builder = new Builder({
+        ui: ui,
+        project: this.project,
+        environment: options.environment,
+        outputPath: options.outputPath
+      });
+
+    return builder.build()
+    .then(function() {
+      var watcher = new Watcher({
+        ui: ui,
+        builder: builder,
+        analytics: _this.analytics,
+        options: options
+      });
+      return testTask.run({
+        outputPath: options.outputPath,
+        watcher: watcher
+      });
+    });
+  },
+
   run: function(options) {
     var _this = this;
     options.outputPath = this.tmp();
 
-    var buildTask = new this.tasks.Build(this.taskOptions());
-
-    return buildTask.run({
+    var promise;
+    // server mode will build continuously
+    if (options.server) {
+      promise = _this.runTestsServer(options);
+    } else {
+      // ci mode
+      var buildTask = new this.tasks.Build(this.taskOptions());
+      promise = buildTask.run({
         environment: options.environment,
         outputPath: options.outputPath
       })
@@ -117,7 +175,9 @@ module.exports = {
       })
       .then(function() {
         return _this.runTests(options);
-      })
-      .finally(this.rmTmp.bind(this));
+      });
+    }
+
+    return promise.finally(this.rmTmp.bind(this));
   }
 };

--- a/lib/commands/nw-test/runner.js
+++ b/lib/commands/nw-test/runner.js
@@ -24,12 +24,11 @@ function runNw(nwPath, testsPath) {
       if (data === '# done with errors') {
         hasErrors = true;
       }
-    }
-  });
 
-  nw.on('exit', function(code) {
-    setTimeout(function() {
-      process.exit(hasErrors ? 1 : code);
-    }, 1);
+      if (data.indexOf('# done') > -1) {
+        nw.kill();
+        process.exit(hasErrors ? 1 : 0);
+      }
+    }
   });
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "author": "Estelle DeBlois",
   "license": "MIT",
   "dependencies": {
+    "broccoli-funnel": "^0.2.3",
+    "broccoli-string-replace": "0.0.2",
     "chalk": "^1.0.0",
     "node-webkit-builder": "^1.0.11",
     "optimist": "0.6.1",

--- a/test-support/node-webkit/qunit-logger.js
+++ b/test-support/node-webkit/qunit-logger.js
@@ -1,6 +1,21 @@
+/* global io */
 // dead stupid script to format test output from nw.js to the console
 import QUnit from 'qunit';
+var socket = io('http://localhost:7357');
 
+socket.on('connect', function(){
+  // connect to testem server
+  socket.emit('browser-login', 'NW.js', '1');
+  console.log('sucessfully connected to test host');
+});
+
+// testem indicated we should re-run
+socket.on('start-tests', function() {
+  socket.disconnect();
+  window.location.reload();
+});
+
+var messages = [];
 function log(content) {
   console.log('[qunit-logger] ' + content);
 }
@@ -10,35 +25,118 @@ export function setQUnitLogger() {
     return;
   }
 
-  var totalTestCount = 0;
-  var testCount = 0;
-  var tests = {};
+  qunitAdapter(socket);
+}
+
+// mostly stolen from
+// https://github.com/airportyh/testem/blob/31e070490cb8835a0b05b4f14fc1a75fe71e130a/public/testem/qunit_adapter.js
+function qunitAdapter(socket){
+
+  var results = {
+      failed: 0,
+      passed: 0,
+      total: 0,
+      tests: []}
+    , currentTest
+    , currentModule
+    , id = 1
+
+  function lineNumber(e){
+      return e.line || e.lineNumber
+  }
+
+  function sourceFile(e){
+      return e.sourceURL || e.fileName
+  }
+
+  function message(e){
+      var msg = (e.name && e.message) ? (e.name + ': ' + e.message) : e.toString()
+      return msg
+  }
+
+  function stacktrace(e){
+      if (e.stack)
+          return e.stack
+      return undefined
+  }
 
   QUnit.begin(function(details) {
     if (details.totalTests >= 1) {
-      totalTestCount = details.totalTests;
       log('1..' + details.totalTests);
     }
   });
 
-  QUnit.testDone(function(details) {
-    testCount++;
-    if (details.failed === 0 && !tests[details.name]) {
-      tests[details.name] = details.name;
-      log('ok ' + testCount + ' - ' + details.module + ' # ' + details.name);
-    }
-  });
+  QUnit.log( function(params, e){
+      if (e){
+          currentTest.items.push({
+              passed: params.result,
+              line: lineNumber(e),
+              file: sourceFile(e),
+              stack: stacktrace(e),
+              message: message(e)
+          })
+      } else{
+          if(params.result) {
+              currentTest.items.push({
+                  passed: params.result,
+                  message: params.message
+              })
+          }
+          else {
+              currentTest.items.push({
+                  passed: params.result,
+                  actual: params.actual,
+                  expected: params.expected,
+                  message: params.message
+              })
+          }
 
-  QUnit.log(function(details) {
-    if (details.result !== true) {
-      var actualTestCount = testCount + 1;
-      log('# ' + JSON.stringify(details));
-      log('not ok ' + actualTestCount + ' - ' + details.module + ' - ' + details.name);
-    }
-  });
+      }
 
-  QUnit.done(function(details) {
-    log('# done' + (details.failed === 0 ? '' : ' with errors'));
-    require('nw.gui').App.quit();
-  });
+      if (params.result !== true) {
+        var actualTestCount = results.total + 1;
+        log('not ok ' + actualTestCount + ' - ' + params.module + ' - ' + params.name);
+      }
+
+  })
+  QUnit.testStart( function(params){
+      currentTest = {
+          id: id++,
+          name: (currentModule ? currentModule + ': ' : '') + params.name,
+          items: []
+      }
+      socket.emit('tests-start')
+  })
+  QUnit.testDone( function(params){
+      currentTest.failed = params.failed
+      currentTest.passed = params.passed
+      currentTest.total = params.total
+
+      results.total++
+      if (currentTest.failed > 0)
+          results.failed++
+      else
+          results.passed++
+
+      results.tests.push(currentTest)
+
+      if (params.failed === 0) {
+        results.tests[params.name] = params.name;
+        log('ok ' + results.total + ' - ' + params.module + ' # ' + params.name);
+      }
+
+      socket.emit('test-result', currentTest)
+  })
+  QUnit.moduleStart( function(params){
+      currentModule = params.name
+  })
+  QUnit.moduleEnd = function(params){
+      currentModule = undefined
+  }
+  QUnit.done( function(params){
+      results.runDuration = params.runtime
+      log('# done' + (params.failed === 0 ? '' : ' with errors'));
+      socket.emit('all-test-results', results);
+  })
+
 }


### PR DESCRIPTION
Creates a 'nw:test --server' switch which starts tests in interactive mode
using testem's server mode. Qunit-logger connects to the server via
web socket and re-runs tests without restarting the process. Interactive
mode shows nwjs where ci mode hides.