### PR TITLE
Clean up test command

### DIFF
--- a/lib/commands/nw-test/index.js
+++ b/lib/commands/nw-test/index.js
@@ -1,30 +1,30 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var RSVP = require('rsvp');
-var denodeify = RSVP.denodeify;
-var readFile = denodeify(fs.readFile);
-var writeFile = denodeify(fs.writeFile);
 var Builder = require('ember-cli/lib/models/builder');
-
-function safePath(filePath) {
-  // Guard against file paths that contain spaces
-  return '"' + filePath + '"';
-}
+var Watcher = require('ember-cli/lib/models/watcher');
 
 module.exports = {
   name: 'nw:test',
   description: 'Runs your test suite in NW.js',
 
   availableOptions: [
-    { name: 'config-file', type: String, aliases: ['c', 'cf'] },
-    { name: 'server', type: Boolean, default: false },
-    { name: 'environment', type: String, default: 'test', aliases: ['e'] }
+    { name: 'environment', type: String, default: 'test', aliases: ['e'] },
+    { name: 'server', type: Boolean, description: 'Run tests in interactive mode', default: false },
+    { name: 'protocol', type: 'String', description: 'The protocol to use when running with --server', default: 'http' },
+    { name: 'host', type: String, description: 'The host to use when running with --server', default: 'localhost', aliases: ['H'] },
+    { name: 'port', type: Number, description: 'The port to use when running with --server', default: 7357, aliases: ['p'] }
   ],
 
   init: function() {
+    this.assign    = require('lodash/object/assign');
     this.quickTemp = require('quick-temp');
+
+    this.Builder = this.Builder || Builder;
+    this.Watcher = this.Watcher || Watcher;
+
+    if (!this.testing) {
+      process.env.EMBER_CLI_TEST_COMMAND = true;
+    }
   },
 
   tmp: function() {
@@ -35,23 +35,6 @@ module.exports = {
     this.quickTemp.remove(this, '-testsDistNW');
   },
 
-  prepareTestFiles: function(options) {
-    var root = this.project.root;
-    var outputPath = options.outputPath;
-
-    var testHtmlPath = path.join(outputPath, 'tests', 'index.html');
-
-    return readFile(testHtmlPath, { encoding: 'utf8' })
-      .then(function(html) {
-        var content = html.replace(/base href="\/"/, 'base href="../"');
-        return writeFile(testHtmlPath, content);
-      })
-      .then(function() {
-        var stream = fs.createReadStream(path.join(root, 'tests', 'package.json'));
-        stream.pipe(fs.createWriteStream(path.join(outputPath, 'tests', 'package.json')));
-      });
-  },
-
   taskOptions: function() {
     return {
       ui: this.ui,
@@ -60,126 +43,59 @@ module.exports = {
     };
   },
 
-  testCommand: function(options) {
-    var findNW = require('../../helpers/find-nw');
+  runTestsForCI: function(options) {
+    var buildTask = new this.tasks.Build(this.taskOptions());
 
-    var command = 'node';
-    var commandArgs = safePath(path.join(__dirname, 'runner.js'));
-    var commandFlags = [
-      '--nw-path=' + safePath(findNW(this.project)),
-      '--tests-path=' + safePath(path.join(options.outputPath, 'tests'))
-    ];
+    var NWTest = this.tasks.Test.extend(require('./task'));
+    var testTask = new NWTest(this.taskOptions());
 
-    return [command, commandArgs].concat(commandFlags).join(' ');
-  },
-
-  runTests: function(options) {
-    var testCommand = this.testCommand(options);
-    var BaseTestTask = this.tasks.Test;
-
-    var TestTask = BaseTestTask.extend({
-      testemOptions: function() {
-        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-        return {
-          cwd: options.outputPath,
-          middleware: this.addonMiddlewares(),
-          launch_in_ci: ['NW.js'],
-          launchers: {
-            'NW.js': {
-              command: testCommand,
-              protocol: 'tap'
-            }
-          },
-          reporter: require('./reporter')
-        };
-      }
+    var testOptions = this.assign({}, options, {
+      outputPath: options.outputPath,
+      reporter: require('./reporter')
     });
 
-    var testTask = new TestTask(this.taskOptions());
-
-    return testTask.run({
-      outputPath: options.outputPath
-    });
-  },
-
-  runTestsServer: function(options) {
-    var _this = this;
-    var BaseTestTask = this.tasks.TestServer;
-
-    process.env.NW_TESTS_DEV = true;
-    process.env.NW_TESTEM_SERVER_URL = 'http://localhost:7357';
-
-    var TestTask = BaseTestTask.extend({
-      testemOptions: function() {
-        var findNW = require('../../helpers/find-nw');
-        var nwPath = safePath(findNW(_this.project));
-        var testPath = safePath(path.join(options.outputPath, 'tests'));
-        var testCommand = nwPath + ' ' + testPath;
-        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
-        return {
-          cwd: options.outputPath,
-          middleware: this.addonMiddlewares(),
-          reporter: require('./reporter'),
-          hide_stderr: false,
-          hide_stdout: false,
-          launch_in_dev: ['NW.js'],
-          launchers: {
-            'NW.js': {
-              command: testCommand,
-              protocol: 'browser'
-            }
-          }
-        };
-      }
-    });
-
-    var testTask = new TestTask(this.taskOptions());
-    var ui = this.ui;
-    var Watcher = require('ember-cli/lib/models/watcher');
-
-    var builder = new Builder({
-        ui: ui,
-        project: this.project,
+    return buildTask.run({
         environment: options.environment,
         outputPath: options.outputPath
+      })
+      .then(function() {
+        return testTask.run(testOptions);
       });
+  },
 
-    return builder.build()
-    .then(function() {
-      var watcher = new Watcher({
-        ui: ui,
-        builder: builder,
-        analytics: _this.analytics,
-        options: options
-      });
-      return testTask.run({
-        outputPath: options.outputPath,
-        watcher: watcher
-      });
+  runTestsForDev: function(options) {
+    process.env.NW_TESTS_DEV = true;
+    process.env.NW_TESTEM_SERVER_URL = options.protocol + '://' + options.host + ':' + options.port;
+
+    var testOptions = this.assign({}, options, {
+      outputPath: options.outputPath,
+      project: this.project
     });
+
+    var taskOptions = this.taskOptions();
+    taskOptions.builder = new this.Builder(testOptions);
+
+    var NWTestServer = this.tasks.TestServer.extend(require('./task'));
+    var testServer = new NWTestServer(taskOptions);
+
+    testOptions.watcher = new this.Watcher(this.assign(taskOptions, {
+      verbose: false,
+      options: options
+    }));
+
+    return testServer.run(testOptions);
   },
 
   run: function(options) {
-    var _this = this;
     options.outputPath = this.tmp();
 
     var promise;
-    // server mode will build continuously
+
     if (options.server) {
-      promise = _this.runTestsServer(options);
+      // server mode will build continuously
+      promise = this.runTestsForDev(options);
     } else {
-      // ci mode
-      var buildTask = new this.tasks.Build(this.taskOptions());
-      promise = buildTask.run({
-        environment: options.environment,
-        outputPath: options.outputPath
-      })
-      .then(function() {
-        return _this.prepareTestFiles(options);
-      })
-      .then(function() {
-        return _this.runTests(options);
-      });
+      promise = this.runTestsForCI(options);
     }
 
     return promise.finally(this.rmTmp.bind(this));

--- a/lib/commands/nw-test/task.js
+++ b/lib/commands/nw-test/task.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var path = require('path');
+var findNW = require('../../helpers/find-nw');
+
+function safePath(filePath) {
+  // Guard against file paths that contain spaces
+  return '"' + filePath + '"';
+}
+
+module.exports = {
+  testemOptions: function(options) {
+    /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+    return {
+      host: options.host,
+      port: options.port,
+      cwd: options.outputPath,
+      reporter: options.reporter,
+      middleware: this.addonMiddlewares(),
+      launch_in_dev: ['NW.js'],
+      launch_in_ci: ['NW.js (CI)'],
+      launchers: {
+        'NW.js': {
+          command: this.nwCommand(options),
+          protocol: 'browser'
+        },
+        'NW.js (CI)': {
+          command: this.nwCommandForCI(options),
+          protocol: 'tap'
+        }
+      }
+    };
+    /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
+  },
+
+  nwCommand: function(options) {
+    var nwPath = safePath(findNW(this.project));
+    var testPath = safePath(path.join(options.outputPath, 'tests'));
+
+    return nwPath + ' ' + testPath;
+  },
+
+  nwCommandForCI: function(options) {
+    var command = 'node';
+    var commandArgs = safePath(path.join(__dirname, './runner.js'));
+    var commandFlags = [
+      '--nw-path=' + safePath(findNW(this.project)),
+      '--tests-path=' + safePath(path.join(options.outputPath, 'tests'))
+    ];
+
+    return [command, commandArgs].concat(commandFlags).join(' ');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "broccoli-funnel": "^0.2.3",
     "broccoli-string-replace": "0.0.2",
     "chalk": "^1.0.0",
+    "lodash": "^3.9.3",
     "node-webkit-builder": "^1.0.11",
     "optimist": "0.6.1",
     "quick-temp": "0.1.2",


### PR DESCRIPTION
* Move testem config to a separate `task.js` file for re-use.
* Refactor `nw-test/index.js` to reduce code duplication.
* Make testem server URL configurable.