### PR TITLE
Add options to filter tests by module name or pattern.

### DIFF
--- a/blueprints/node-webkit/files/tests/package.json
+++ b/blueprints/node-webkit/files/tests/package.json
@@ -1,7 +1,4 @@
 {
   "name": "ember-nw-test",
-  "main": "index.html",
-  "window": {
-    "show": true
-  }
+  "main": "index.html"
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,24 @@ module.exports = {
         destDir: '/tests'
       });
 
+      var testPageOptions = process.env.NW_TEST_PAGE_OPTIONS;
+
+      if (testPageOptions) {
+        testPkg = replace(testPkg, {
+          files: ['tests/package.json'],
+          patterns: [
+            {
+              match: /"main":\s*"(index.html\?[^\"]+)"/,
+              replacement: '"main": "$1&' + testPageOptions + '"'
+            },
+            {
+              match: /"main":\s*"index.html"/,
+              replacement: '"main": "index.html?' + testPageOptions + '"'
+            }
+          ]
+        });
+      }
+
       return mergeTrees([tree, index, testPkg], { overwrite: true });
     }
 

--- a/lib/commands/nw-test/index.js
+++ b/lib/commands/nw-test/index.js
@@ -12,7 +12,9 @@ module.exports = {
     { name: 'server', type: Boolean, description: 'Run tests in interactive mode', default: false },
     { name: 'protocol', type: 'String', description: 'The protocol to use when running with --server', default: 'http' },
     { name: 'host', type: String, description: 'The host to use when running with --server', default: 'localhost', aliases: ['H'] },
-    { name: 'port', type: Number, description: 'The port to use when running with --server', default: 7357, aliases: ['p'] }
+    { name: 'port', type: Number, description: 'The port to use when running with --server', default: 7357, aliases: ['p'] },
+    { name: 'module', type: String,  description: 'The name of a test module to run', aliases: ['m'] },
+    { name: 'filter', type: String,  description: 'A string to filter tests to run', aliases: ['f'] }
   ],
 
   init: function() {
@@ -67,6 +69,13 @@ module.exports = {
     process.env.NW_TESTS_DEV = true;
     process.env.NW_TESTEM_SERVER_URL = options.protocol + '://' + options.host + ':' + options.port;
 
+    // Test filtering
+    var queryString = this.getTestPageQueryString(options);
+    if (queryString.length > 0) {
+      process.env.NW_TEST_PAGE_OPTIONS = queryString;
+    }
+
+    // Start the test server task
     var testOptions = this.assign({}, options, {
       outputPath: options.outputPath,
       project: this.project
@@ -84,6 +93,20 @@ module.exports = {
     }));
 
     return testServer.run(testOptions);
+  },
+
+  getTestPageQueryString: function(options) {
+    var params = [];
+
+    if (options.module) {
+      params.push('module=' + options.module);
+    }
+
+    if (options.filter) {
+      params.push('filter=' + options.filter.toLowerCase());
+    }
+
+    return params.join('&');
   },
 
   run: function(options) {


### PR DESCRIPTION
* Add `module` and `filter` options for the `nw:test` command
* Options are only available when running with `--server` flag