### PR TITLE
Bump versions of dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
-.DS_STORE
+
 # compiled output
 /dist
 /tmp

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+tests/
+tmp/
+dist/
+
+.editorconfig
+.ember-cli
+.travis.yml
+.npmignore
+**/.gitkeep
+Brocfile.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ cache:
     - node_modules
 
 before_install:
-  - npm config set spin false
-  - npm install -g npm@^2
+  - "npm config set spin false"
+  - "npm install -g npm@^2"
 
 install:
   - npm install

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp"]
+}

--- a/package.json
+++ b/package.json
@@ -16,26 +16,26 @@
     "broccoli-string-replace": "0.0.2",
     "chalk": "^1.0.0",
     "lodash": "^3.9.3",
-    "node-webkit-builder": "^1.0.11",
+    "node-webkit-builder": "^1.0.12",
     "optimist": "0.6.1",
     "quick-temp": "0.1.2",
-    "rsvp": "^3.0.17",
-    "testem": "0.8.2"
+    "rsvp": "^3.0.18",
+    "testem": "0.8.3"
   },
   "devDependencies": {
     "broccoli-jscs": "0.0.22",
-    "broccoli-jshint": "0.5.5",
+    "broccoli-jshint": "0.5.6",
     "broccoli-merge-trees": "0.2.1",
     "chai": "^2.1.1",
     "chai-as-promised": "^4.3.0",
-    "ember-cli": "0.2.3",
+    "ember-cli": "0.2.7",
     "glob": "^5.0.3",
-    "mocha": "^2.2.1",
-    "mocha-jscs": "^1.0.2",
+    "mocha": "^2.2.5",
+    "mocha-jscs": "^1.1.0",
     "mocha-jshint": "^1.0.0",
-    "mock-spawn": "0.2.4",
+    "mock-spawn": "0.2.5",
     "mockery": "^1.4.0",
-    "sinon": "^1.14.1"
+    "sinon": "^1.15.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Bump `ember-cli` to `0.2.7` and `node-webkit-builder` to `1.0.12`, among others.

Closes #26.